### PR TITLE
Adding documentation for GraalVM installation in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ brew install gh
 
 You must install Java 8, 11 and 17. You must set the `JAVA8_HOME`, `JAVA11_HOME` and `JAVA17_HOME` environment variables to the respective Java installations.
 
+You should also install [GraalVM](https://www.graalvm.org/downloads/) and set a `GRAALVM_HOME` environment variable to the home of the GraalVM JDK installation. At the time of writing, GraalVM JDK v23 seems to work for the setup.
 ---
 
 ## Run the code

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ brew install gh
 
 You must install Java 8, 11 and 17. You must set the `JAVA8_HOME`, `JAVA11_HOME` and `JAVA17_HOME` environment variables to the respective Java installations.
 
-You should also install [GraalVM](https://www.graalvm.org/downloads/) and set a `GRAALVM_HOME` environment variable to the home of the GraalVM JDK installation. At the time of writing, GraalVM JDK v23 seems to work for the setup.
----
+By default, you should install [GraalVM](https://www.graalvm.org/downloads/) (version 21 or later) and set a `GRAALVM_HOME` environment variable to the home of the GraalVM JDK installation.
+(Todo: the pipeline should be made to work with regular JDK.  The correctness outputs will be reliable, but no timing information should be output.)
 
 ## Run the code
 


### PR DESCRIPTION
When running the `make small-test` command, I noticed that the `run.sh` script required a `GRAALVM_HOME` [environment variable](https://github.com/benedikt-schesch/AST-Merging-Evaluation/blob/main/run.sh#L130) to be set. I did not have a GraalVM JDK installed, and I don't believe the documentation mentions this. So I'm adding a brief comment so on it so that others don't miss this.

I've specified the version that I used here. I initially installed GraalVM JDK v17, but then `make small-test` failed, because it tried to access the `-H:±UnlockExperimentalVMOptions` option if I recall correctly (this seems to have been introduced in [GraalVM JDK v21](https://www.graalvm.org/release-notes/JDK_21/)).